### PR TITLE
feat: Implement RenameFS and SyncWriterFile interfaces

### DIFF
--- a/file.go
+++ b/file.go
@@ -56,8 +56,8 @@ type s3WriterFile struct {
 }
 
 var (
-	_ wfs.WriterFile = (*s3WriterFile)(nil)
-	_ fs.FileInfo    = (*s3WriterFile)(nil)
+	_ wfs.SyncWriterFile = (*s3WriterFile)(nil)
+	_ fs.FileInfo        = (*s3WriterFile)(nil)
 )
 
 func newS3WriterFile(fsys *S3FS, key string) *s3WriterFile {
@@ -108,6 +108,12 @@ func (f *s3WriterFile) Read(p []byte) (int, error) {
 		return 0, &fs.PathError{Op: "Read", Path: f.key, Err: fs.ErrClosed}
 	}
 	return f.buf.Read(p)
+}
+
+// Sync is a no-op. S3 does not support partial flushes; the entire object
+// is written atomically on Close.
+func (f *s3WriterFile) Sync() error {
+	return nil
 }
 
 // Stat returns the fs.FileInfo of this file.

--- a/fs.go
+++ b/fs.go
@@ -23,6 +23,7 @@ import (
 type S3API interface {
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	CopyObject(ctx context.Context, params *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
 	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 	DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
@@ -55,6 +56,7 @@ var (
 	_ fs.SubFS         = (*S3FS)(nil)
 	_ wfs.WriteFileFS  = (*S3FS)(nil)
 	_ wfs.RemoveFileFS = (*S3FS)(nil)
+	_ wfs.RenameFS     = (*S3FS)(nil)
 )
 
 // New returns a filesystem for the tree of objects rooted at the specified bucket.
@@ -333,6 +335,32 @@ func (fsys *S3FS) WriteFile(name string, p []byte, mode fs.FileMode) (int, error
 		return 0, toPathError(err, "Write", name)
 	}
 	return n, w.Close()
+}
+
+// Rename renames oldpath to newpath using S3 CopyObject followed by DeleteObject.
+func (fsys *S3FS) Rename(oldpath, newpath string) error {
+	api, err := fsys.client()
+	if err != nil {
+		return toPathError(err, "Rename", oldpath)
+	}
+	copySource := path.Join(fsys.bucket, fsys.key(oldpath))
+	_, err = api.CopyObject(fsys.Context(), &s3.CopyObjectInput{
+		Bucket:     aws.String(fsys.bucket),
+		Key:        aws.String(fsys.key(newpath)),
+		CopySource: aws.String(copySource),
+	})
+	if err != nil {
+		return toPathError(err, "Rename", oldpath)
+	}
+
+	_, err = api.DeleteObject(fsys.Context(), &s3.DeleteObjectInput{
+		Bucket: aws.String(fsys.bucket),
+		Key:    aws.String(fsys.key(oldpath)),
+	})
+	if err != nil {
+		return toPathError(err, "Rename", oldpath)
+	}
+	return nil
 }
 
 // RemoveFile removes the specified named file.

--- a/fs_test.go
+++ b/fs_test.go
@@ -68,6 +68,13 @@ func (m *mockFSS3API) PutObject(ctx context.Context, input *s3.PutObjectInput, o
 	return m.fsS3api.PutObject(ctx, input, optFns...)
 }
 
+func (m *mockFSS3API) CopyObject(ctx context.Context, input *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.fsS3api.CopyObject(ctx, input, optFns...)
+}
+
 func (m *mockFSS3API) ListObjectsV2(ctx context.Context, input *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -89,6 +96,17 @@ func TestWriteFileFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := wfstest.TestWriteFileFS(fsys, tmpDir); err != nil {
+		t.Errorf("Error wfstest: %+v", err)
+	}
+}
+
+func TestRenameFS(t *testing.T) {
+	fsys := NewWithClient("testdata", newMockFSS3APITesting(t))
+	tmpDir := "test_rename"
+	if err := wfs.MkdirAll(fsys, tmpDir, fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := wfstest.TestRenameFS(fsys, tmpDir); err != nil {
 		t.Errorf("Error wfstest: %+v", err)
 	}
 }

--- a/s3api.go
+++ b/s3api.go
@@ -104,6 +104,29 @@ func (api *fsS3api) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...
 	return output, nil
 }
 
+// CopyObject API operation for the filesystem.
+func (api *fsS3api) CopyObject(_ context.Context, input *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	src := aws.ToString(input.CopySource)
+	dst := path.Join(aws.ToString(input.Bucket), aws.ToString(input.Key))
+
+	f, err := api.fsys.Open(src)
+	if err != nil {
+		return nil, toS3NoSuchKeyIfNoExist(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	w, err := wfs.CreateFile(api.fsys, dst, fs.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = w.Close() }()
+
+	if _, err := io.Copy(w, f); err != nil {
+		return nil, err
+	}
+	return &s3.CopyObjectOutput{}, nil
+}
+
 func (api *fsS3api) namePrefixes(dirPtr, prefixPtr *string) (string, string, error) {
 	prefix := aws.ToString(prefixPtr)
 	namePrefix := ""


### PR DESCRIPTION
## Summary

- Add `CopyObject` to `S3API` interface
- Implement `wfs.RenameFS` via CopyObject + DeleteObject
- Implement `wfs.SyncWriterFile` as no-op (S3 writes atomically on Close)
- Add `TestRenameFS` using `wfstest`

## Test plan

- [x] All unit tests pass (`go test -race ./...`)
- [x] golangci-lint passes with zero issues
- [x] `TestRenameFS` passes via `wfstest.TestRenameFS`