### PR TITLE
docs: Add CHANGELOG.md and update README for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0]
+
+### Added
+
+- `wfs.RenameFS` support via S3 CopyObject + DeleteObject.
+- `wfs.SyncWriterFile` support (no-op — S3 writes atomically on Close).
+- `S3API` interface defined in this package for testability.
+- Builder methods: `WithClient`, `WithConfig`, `WithContext`.
+- `NewWithClient` convenience constructor.
+- Lazy client initialization — `New(bucket)` defers AWS config loading
+  until the first operation.
+- CI: GitHub Actions with Go version matrix (`1.24`, `stable`),
+  golangci-lint, govulncheck.
+- Dependabot for weekly Go module and GitHub Actions updates.
+- `CHANGELOG.md`.
+
+### Changed
+
+- **Breaking:** Migrated from `aws-sdk-go` (v1) to `aws-sdk-go-v2`.
+- **Breaking:** `New(bucket)` no longer takes `context.Context` or
+  returns `error`. Use `WithContext` to set a context.
+- **Breaking:** `NewWithSession` removed. Use `NewWithClient` or
+  `New(bucket).WithConfig(cfg)`.
+- **Breaking:** `NewWithAPI` renamed to `NewWithClient`. The parameter
+  type changed from `s3iface.S3API` to the `S3API` interface defined in
+  this package.
+- Upgraded `wfs` dependency from v0.4.0 to v0.5.0.
+- Removed `io2` dependency (replaced with internal `lazyReadCloser`).
+- Minimum Go version set to 1.24.
+
+## [0.3.0] and earlier
+
+See the git log.
+
+[Unreleased]: https://github.com/mojatter/s3fs/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/mojatter/s3fs/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# github.com/mojatter/s3fs
+# s3fs
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/mojatter/s3fs)](https://pkg.go.dev/github.com/mojatter/s3fs)
 [![Report Card](https://goreportcard.com/badge/github.com/mojatter/s3fs)](https://goreportcard.com/report/github.com/mojatter/s3fs)
+[![Tests](https://github.com/mojatter/s3fs/actions/workflows/tests.yaml/badge.svg)](https://github.com/mojatter/s3fs/actions/workflows/tests.yaml)
 
 Package s3fs provides an implementation of [wfs](https://github.com/mojatter/wfs) for S3.
+
+Requires Go 1.24 or later.
 
 ## Examples
 
@@ -41,8 +44,8 @@ import (
   "io/fs"
   "log"
 
-  "github.com/mojatter/wfs"
   "github.com/mojatter/s3fs"
+  "github.com/mojatter/wfs"
 )
 
 func main() {
@@ -54,9 +57,52 @@ func main() {
 }
 ```
 
+### Explicit client
+
+When you need to control the AWS configuration (region, credentials,
+custom endpoint, etc.), construct the S3 client yourself and pass it in:
+
+```go
+package main
+
+import (
+  "context"
+  "log"
+
+  "github.com/aws/aws-sdk-go-v2/config"
+  "github.com/aws/aws-sdk-go-v2/service/s3"
+  "github.com/mojatter/s3fs"
+)
+
+func main() {
+  ctx := context.Background()
+  cfg, err := config.LoadDefaultConfig(ctx)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fsys := s3fs.NewWithClient("<your-bucket>", s3.NewFromConfig(cfg)).
+    WithContext(ctx)
+  // use fsys ...
+  _ = fsys
+}
+```
+
+## Capability layers
+
+s3fs implements the following [wfs](https://github.com/mojatter/wfs)
+capability interfaces:
+
+| Capability | Interface | Notes |
+| --- | --- | --- |
+| Read | `fs.FS`, `fs.GlobFS`, `fs.ReadDirFS`, `fs.ReadFileFS`, `fs.StatFS`, `fs.SubFS` | |
+| Write | `wfs.WriteFileFS` | `MkdirAll` is a no-op (S3 has no directories) |
+| Remove | `wfs.RemoveFileFS` | |
+| Rename | `wfs.RenameFS` | Implemented via CopyObject + DeleteObject |
+| Sync | `wfs.SyncWriterFile` | No-op (S3 writes atomically on Close) |
+
 ## Tests
 
-S3FS can pass TestFS in "testing/fstest".
+s3fs can pass TestFS in `testing/fstest`.
 
 ```go
 import (


### PR DESCRIPTION
## Summary

- Add CI badge, Go version requirement, explicit client example to README
- Document capability layers (RenameFS, SyncWriterFile)
- Add CHANGELOG.md covering all v0.4.0 changes

Depends on #8.

## Test plan

- [x] No code changes — documentation only